### PR TITLE
updated versions of all subpackages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "streamlit",
+    "openmc_geometry_plot>=0.4.2",
     "openmc_source_plotter>=0.7.0",
     "dagmc_geometry_slice_plotter>=0.3.1",
-    "openmc_geometry_plot>=0.4.2",
     "openmc_regular_mesh_plotter>=1.2.1",
     "openmc_depletion_plotter>=0.4.0",
-    "openmc_cylindrical_mesh_plotter>=0.3.2",
+    "openmc_cylindrical_mesh_plotter>=0.3.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "openmc_geometry_plot>=0.4.2",
     "openmc_regular_mesh_plotter>=1.2.1",
     "openmc_depletion_plotter>=0.4.0",
-    "openmc_cylindrical_mesh_plotter>=0.3.2",
+    "openmc_cylindrical_mesh_plotter>=0.3.3",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,12 @@ classifiers = [
 ]
 dependencies = [
     "streamlit",
-    "openmc_source_plotter>=0.6.2",
+    "openmc_source_plotter>=0.7.0",
     "dagmc_geometry_slice_plotter>=0.3.1",
-    "openmc_geometry_plot>=0.3.5",
-    "regular_mesh_plotter>=0.5.3",
-    "openmc_depletion_plotter>=0.3.1",
-    "openmc_cylindrical_mesh_plotter>=0.1.2",
+    "openmc_geometry_plot>=0.4.2",
+    "openmc_regular_mesh_plotter>=1.2.1",
+    "openmc_depletion_plotter>=0.4.0",
+    "openmc_cylindrical_mesh_plotter>=0.3.2",
 ]
 dynamic = ["version"]
 
@@ -52,3 +52,4 @@ package-dir = {"" = "src"}
 
 [project.scripts]
 openmc_plot = "openmc_plot.launch:main"
+openmc-plot = "openmc_plot.launch:main"

--- a/src/openmc_plot/app.py
+++ b/src/openmc_plot/app.py
@@ -30,7 +30,7 @@ hide_streamlit_style = """
             """
 st.markdown(hide_streamlit_style, unsafe_allow_html=True)
 
-version = "v0.3.0"
+version = "v0.3.1"
 location = os.getenv("OPENMC_PLOT_LOCATION")
 
 if location == "cloud":
@@ -44,10 +44,8 @@ if location == "cloud":
             
             ### 🐍 Install with Python ```pip install openmc_plot``` then run with ```openmc_plot```
 
-
             💾 Raise a feature request, report and issue or make a contribution on [GitHub](https://github.com/fusion-energy/openmc_plot)
 
-            📧 Email feedback to mail@jshimwell.com
         """
     )
 else:

--- a/src/openmc_plot/pages/1_🖼_Geometry_plot.py
+++ b/src/openmc_plot/pages/1_🖼_Geometry_plot.py
@@ -1,21 +1,9 @@
-import xml.etree.ElementTree as ET
-from pathlib import Path
-import plotly.graph_objects as go
-import matplotlib.pyplot as plt
-import openmc
 import streamlit as st
-from matplotlib import colors
-from pylab import cm, colormaps
-import numpy as np
-
-import openmc_geometry_plot  # adds extra functions to openmc.Geometry
-
-from utils import save_uploadedfile
-
+import openmc_geometry_plot
 
 def header():
     st.write(
-        f"""This tab makes use of the 🐍 Python package ```openmc_geometry_plot v{openmc_geometry_plot.__version__}``` which is available on [GitHub](https://github.com/fusion-energy/openmc_geometry_plot)."""
+        f"""This tab makes use of the 🐍 Python package ```openmc_geometry_plot v{openmc_geometry_plot.__version__}``` which is available separately on [GitHub](https://github.com/fusion-energy/openmc_geometry_plot)."""
     )
 
 header()

--- a/src/openmc_plot/pages/2_🧊_Regular_mesh_plot.py
+++ b/src/openmc_plot/pages/2_🧊_Regular_mesh_plot.py
@@ -7,13 +7,13 @@ from pylab import *
 from matplotlib.colors import LogNorm
 import plotly.graph_objects as go
 import numpy as np
-import regular_mesh_plotter
+import openmc_regular_mesh_plotter
 import xml.etree.ElementTree as ET
 
 
 st.write(
     f"""
-    This tab makes use of the 🐍 Python package ```regular_mesh_plotter v{regular_mesh_plotter.__version__}``` which is available on [GitHub](https://github.com/fusion-energy/regular_mesh_plotter).
+    This tab makes use of the 🐍 Python package ```openmc_regular_mesh_plotter v{openmc_regular_mesh_plotter.__version__}``` which is available on [GitHub](https://github.com/fusion-energy/regular_mesh_plotter).
     """
 )
 


### PR DESCRIPTION
versions have all been updated. But I think further work is needed before this pr is ready.

What we could do is add optional guis to all packages and move the gui logic from openmc_plot to the subpackages

- [ ] openmc_geometry_plot
    - [x] update to >=0.4.3
    - [x] streamlit gui 
    - [x] used directly in openmc_plot
- [ ] openmc_source_plotter
    - [x] update to >=0.7.0
    - [ ] streamlit gui 
    - [ ] optional streamlit gui 
    - [ ] used directly in openmc_plot
- [ ] dagmc_geometry_slice_plotter
    - [x] update to >=0.3.1
    - [x] streamlit gui 
    - [ ] optional streamlit gui 
    - [x] used directly in openmc_plot
- [ ] openmc_regular_mesh_plotter
    - [x] update to >=1.2.1
    - [ ] streamlit gui 
    - [ ] optional streamlit gui 
    - [ ] used directly in openmc_plot
- [ ] openmc_depletion_plotter
    - [x] update to >=0.4.0
    - [x] streamlit gui 
    - [ ] optional streamlit gui 
    - [x] used directly in openmc_plot
    - [ ] monkey patch needs removing
- [x] openmc_cylindrical_mesh_plotter
    - [x] update to >=0.3.3
    - [x] streamlit gui 
    - [x] optional streamlit gui 
    - [x] used directly in openmc_plot